### PR TITLE
🎉  trying chapter #1

### DIFF
--- a/src/Chapter1.hs
+++ b/src/Chapter1.hs
@@ -492,7 +492,7 @@ Implement a function that returns the last digit of a given number.
 -}
 -- DON'T FORGET TO SPECIFY THE TYPE IN HERE
 lastDigit :: Int -> Int
-lastDigit n = mod n 10
+lastDigit n = mod (abs n) 10
 
 
 {- |
@@ -530,7 +530,7 @@ closestToZero x y = if abs x > abs y then y else x
 Write a function that returns the middle number among three given numbers.
 
 >>> mid 3 1 2
-1
+2
 
 🕯 HINT: When checking multiple conditions, it is more convenient to use the
   language construct called "guards" instead of multiple nested 'if-then-else'
@@ -557,7 +557,12 @@ Casual reminder about adding top-level type signatures for all functions :)
 -}
 
 mid :: Int -> Int -> Int -> Int
-mid _ y _ = y
+mid x y z
+  | x <= y && y <= z = y
+  | z <= y && y <= x = y
+  | y <= x && x <= z = x
+  | z <= x && x <= y = x
+  | otherwise = z 
 
 {- |
 =⚔️= Task 8
@@ -639,8 +644,8 @@ specifying complex expressions.
 sumLast2 :: Int -> Int
 sumLast2 n = a + b
   where
-    a = div (n `mod` 100) 10
-    b = n `mod` 10
+    a = div ((abs n) `mod` 100) 10
+    b = (abs n) `mod` 10
 
 
 {- |
@@ -663,8 +668,8 @@ aren't ready for this boss yet!
 
 firstDigit :: Int -> Int
 firstDigit n
-  | div n 10 == 0 = n
-  | div n 10 > 0 = firstDigit (div n 10)
+  | div (abs n) 10 == 0 = abs n
+  | div (abs n) 10 > 0 = firstDigit (div (abs n) 10)
 
 
 

--- a/src/Chapter1.hs
+++ b/src/Chapter1.hs
@@ -577,7 +577,7 @@ True
 False
 -}
 isVowel :: Char -> Bool
-isVowel c = if c `elem` ['a', 'e', 'i', 'o', 'u'] then True else False
+isVowel c = c `elem` ['a', 'e', 'i', 'o', 'u']
 
 
 {- |
@@ -668,9 +668,9 @@ aren't ready for this boss yet!
 
 firstDigit :: Int -> Int
 firstDigit n
-  | div (abs n) 10 == 0 = abs n
-  | div (abs n) 10 > 0 = firstDigit (div (abs n) 10)
-
+  | div10 n == 0 = abs n
+  | div10 n > 0 = firstDigit (div10 n)
+  where div10 n = div (abs n) 10  
 
 
 {-

--- a/src/Chapter1.hs
+++ b/src/Chapter1.hs
@@ -491,7 +491,7 @@ Implement a function that returns the last digit of a given number.
   whether it works for you!
 -}
 -- DON'T FORGET TO SPECIFY THE TYPE IN HERE
-lastDigit :: Integer -> Integer
+lastDigit :: Int -> Int
 lastDigit n = mod n 10
 
 

--- a/src/Chapter1.hs
+++ b/src/Chapter1.hs
@@ -209,31 +209,31 @@ So, the output in this example means that 'False' has type 'Bool'.
 > Try to guess first and then compare your expectations with GHCi output
 
 >>> :t True
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+True :: Bool
 >>> :t 'a'
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+'a' :: Char
 >>> :t 42
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+42 :: Num p => p
 
 A pair of boolean and char:
 >>> :t (True, 'x')
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+(True, 'x') :: (Bool, Char)
 
 Boolean negation:
 >>> :t not
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+not :: Bool -> Bool
 
 Boolean 'and' operator:
 >>> :t (&&)
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+(&&) :: Bool -> Bool -> Bool
 
 Addition of two numbers:
 >>> :t (+)
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+(+) :: Num a => a -> a -> a
 
 Maximum of two values:
 >>> :t max
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+max :: Ord a => a -> a -> a
 
 You might not understand each type at this moment, but don't worry! You've only
 started your Haskell journey. Types will become your friends soon.
@@ -301,43 +301,43 @@ expressions in GHCi
   functions and operators first. Remember this from the previous task? ;)
 
 >>> 1 + 2
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+3
 
 >>> 10 - 15
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+-5
 
 >>> 10 - (-5)  -- negative constants require ()
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+15
 
 >>> (3 + 5) < 10
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+True
 
 >>> True && False
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+False
 
 >>> 10 < 20 || 20 < 5
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+True
 
 >>> 2 ^ 10  -- power
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+1024
 
 >>> not False
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+True
 
 >>> div 20 3  -- integral division
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+6
 
 >>> mod 20 3  -- integral division remainder
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+2
 
 >>> max 4 10
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+10
 
 >>> min 5 (max 1 2)
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+2
 
 >>> max (min 1 10) (min 5 7)
-<INSERT THE RESULT INSTEAD OF THE TEXT>
+5
 
 Because Haskell is a __statically-typed__ language, you see an error each time
 you try to mix values of different types in situations where you are not
@@ -429,6 +429,7 @@ task is to specify the type of this function.
 49
 -}
 
+squareSum :: Int -> Int -> Int
 squareSum x y = (x + y) * (x + y)
 
 
@@ -449,7 +450,7 @@ Implement the function that takes an integer value and returns the next 'Int'.
   function body with the proper implementation.
 -}
 next :: Int -> Int
-next x = error "next: not implemented!"
+next x = x + 1
 
 {- |
 After you've implemented the function (or even during the implementation), you
@@ -490,7 +491,8 @@ Implement a function that returns the last digit of a given number.
   whether it works for you!
 -}
 -- DON'T FORGET TO SPECIFY THE TYPE IN HERE
-lastDigit n = error "lastDigit: Not implemented!"
+lastDigit :: Integer -> Integer
+lastDigit n = mod n 10
 
 
 {- |
@@ -520,7 +522,7 @@ branches because it is an expression and it must always return some value.
   satisfying the check will be returned and, therefore, evaluated.
 -}
 closestToZero :: Int -> Int -> Int
-closestToZero x y = error "closestToZero: not implemented!"
+closestToZero x y = if abs x > abs y then y else x 
 
 
 {- |
@@ -528,7 +530,7 @@ closestToZero x y = error "closestToZero: not implemented!"
 Write a function that returns the middle number among three given numbers.
 
 >>> mid 3 1 2
-2
+1
 
 🕯 HINT: When checking multiple conditions, it is more convenient to use the
   language construct called "guards" instead of multiple nested 'if-then-else'
@@ -554,7 +556,8 @@ value after "=" where the condition is true.
 Casual reminder about adding top-level type signatures for all functions :)
 -}
 
-mid x y z = error "mid: not implemented!"
+mid :: Int -> Int -> Int -> Int
+mid _ y _ = y
 
 {- |
 =⚔️= Task 8
@@ -568,7 +571,8 @@ True
 >>> isVowel 'x'
 False
 -}
-isVowel c = error "isVowel: not implemented!"
+isVowel :: Char -> Bool
+isVowel c = if c `elem` ['a', 'e', 'i', 'o', 'u'] then True else False
 
 
 {- |
@@ -632,7 +636,11 @@ Try to introduce variables in this task (either with let-in or where) to avoid
 specifying complex expressions.
 -}
 
-sumLast2 n = error "sumLast2: Not implemented!"
+sumLast2 :: Int -> Int
+sumLast2 n = a + b
+  where
+    a = div (n `mod` 100) 10
+    b = n `mod` 10
 
 
 {- |
@@ -653,7 +661,11 @@ You need to use recursion in this task. Feel free to return to it later, if you
 aren't ready for this boss yet!
 -}
 
-firstDigit n = error "firstDigit: Not implemented!"
+firstDigit :: Int -> Int
+firstDigit n
+  | div n 10 == 0 = n
+  | div n 10 > 0 = firstDigit (div n 10)
+
 
 
 {-


### PR DESCRIPTION
### Solutions for Chapter 1

cc @vrom911 @chshersh 

First of all thanks for this amazing project!!!

The docs are really well written - its a great mixtuer of precise vocabularity and a good explaination of these constructs. 

## Bugs occured

https://github.com/kowainik/learn4haskell/compare/main...capital-G:solution-chapter1?expand=1#diff-540a810f208f97454f6e027d5774ce78f88d941006e6e9ef34c06c4b7390f759L531 seems off but maybe thats just me b/c its late.

Running the test suite results in where I am actually a bit lost

```
➜ make test-chapter1
cabal test doctest-chapter1 --enable-tests --test-show-details=direct
Build profile: -w ghc-8.10.1 -O1
In order, the following will be built (use -v for more details):
 - learn4haskell-0.0.0.0 (test:doctest-chapter1) (first run)
Preprocessing test suite 'doctest-chapter1' for learn4haskell-0.0.0.0..
Building test suite 'doctest-chapter1' for learn4haskell-0.0.0.0..
Running 1 test suites...
Test suite doctest-chapter1: RUNNING...
Examples: 38  Tried: 38  Errors: 0  Failures: 0
Test suite doctest-chapter1: PASS
Test suite logged to:
/Users/XXX/code/learn4haskell/dist-newstyle/build/x86_64-osx/ghc-8.10.1/learn4haskell-0.0.0.0/t/doctest-chapter1/test/learn4haskell-0.0.0.0-doctest-chapter1.log
1 of 1 test suites (1 of 1 test cases) passed.
cabal run learn4haskell-test --enable-tests -- -m "Chapter1"
Build profile: -w ghc-8.10.1 -O1
In order, the following will be built (use -v for more details):
 - happy-1.20.0 (exe:happy) (requires build)
 - quickcheck-io-0.2.0 (lib) (requires build)
 - pretty-show-1.10 (lib) (requires build)
 - hspec-core-2.7.4 (lib) (requires build)
 - hedgehog-1.0.4 (lib) (requires build)
 - hspec-2.7.4 (lib) (requires build)
 - hspec-hedgehog-0.0.1.2 (lib) (requires build)
 - learn4haskell-0.0.0.0 (test:learn4haskell-test) (first run)
Starting     quickcheck-io-0.2.0 (lib)
Starting     happy-1.20.0 (exe:happy)
Building     quickcheck-io-0.2.0 (lib)
Building     happy-1.20.0 (exe:happy)
Installing   quickcheck-io-0.2.0 (lib)
Completed    quickcheck-io-0.2.0 (lib)
Starting     hspec-core-2.7.4 (lib)
Building     hspec-core-2.7.4 (lib)
Installing   hspec-core-2.7.4 (lib)
Completed    hspec-core-2.7.4 (lib)
Starting     hspec-2.7.4 (lib)
Building     hspec-2.7.4 (lib)
Installing   hspec-2.7.4 (lib)
Completed    hspec-2.7.4 (lib)

Failed to build exe:happy from happy-1.20.0.
Build log ( /Users/XXX/.cabal/logs/ghc-8.10.1/hppy-1.20.0-9ac48e58.log ):
Configuring executable 'happy' for happy-1.20.0..
Preprocessing executable 'happy' for happy-1.20.0..
Building executable 'happy' for happy-1.20.0..
[ 1 of 19] Compiling AbsSyn           ( src/AbsSyn.lhs, dist/build/happy/happy-tmp/AbsSyn.o )
[ 2 of 19] Compiling GenUtils         ( src/GenUtils.lhs, dist/build/happy/happy-tmp/GenUtils.o )
[ 3 of 19] Compiling NameSet          ( src/NameSet.hs, dist/build/happy/happy-tmp/NameSet.o )
[ 4 of 19] Compiling ParamRules       ( src/ParamRules.hs, dist/build/happy/happy-tmp/ParamRules.o )
[ 5 of 19] Compiling ParseMonad       ( src/ParseMonad.hs, dist/build/happy/happy-tmp/ParseMonad.o )
[ 6 of 19] Compiling Lexer            ( src/Lexer.lhs, dist/build/happy/happy-tmp/Lexer.o )
[ 7 of 19] Compiling AttrGrammar      ( src/AttrGrammar.lhs, dist/build/happy/happy-tmp/AttrGrammar.o )
[ 8 of 19] Compiling AttrGrammarParser ( src/AttrGrammarParser.hs, dist/build/happy/happy-tmp/AttrGrammarParser.o )
[ 9 of 19] Compiling Grammar          ( src/Grammar.lhs, dist/build/happy/happy-tmp/Grammar.o )
[10 of 19] Compiling LALR             ( src/LALR.lhs, dist/build/happy/happy-tmp/LALR.o )
[11 of 19] Compiling First            ( src/First.lhs, dist/build/happy/happy-tmp/First.o )
[12 of 19] Compiling Parser           ( src/Parser.hs, dist/build/happy/happy-tmp/Parser.o )
[13 of 19] Compiling Paths_happy      ( dist/build/happy/autogen/Paths_happy.hs, dist/build/happy/happy-tmp/Paths_happy.o )
[14 of 19] Compiling Info             ( src/Info.lhs, dist/build/happy/happy-tmp/Info.o )
[15 of 19] Compiling PrettyGrammar    ( src/PrettyGrammar.hs, dist/build/happy/happy-tmp/PrettyGrammar.o )
[16 of 19] Compiling ProduceGLRCode   ( src/ProduceGLRCode.lhs, dist/build/happy/happy-tmp/ProduceGLRCode.o )
[17 of 19] Compiling Target           ( src/Target.lhs, dist/build/happy/happy-tmp/Target.o )
[18 of 19] Compiling ProduceCode      ( src/ProduceCode.lhs, dist/build/happy/happy-tmp/ProduceCode.o )
[19 of 19] Compiling Main             ( src/Main.lhs, dist/build/happy/happy-tmp/Main.o )
Linking dist/build/happy/happy ...
Undefined symbols for architecture x86_64:
  "___darwin_check_fd_set_overflow", referenced from:
      _awaitEvent in libHSrts.a(Select.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
`clang' failed in phase `Linker'. (Exit code: 1)
cabal: Failed to build exe:happy from happy-1.20.0 (which is required by
test:learn4haskell-test from learn4haskell-0.0.0.0). See the build log above
for details.

make: *** [test-chapter1] Error 1

```